### PR TITLE
Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+sudo: required
+
+language: bash
+
+services:
+  - docker
+
+install:
+  - docker build -t quay.io/wikiwatershed/rwd:${TRAVIS_COMMIT:0:7} .
+
+script:
+  - docker run -d --name rwd quay.io/wikiwatershed/rwd:${TRAVIS_COMMIT:0:7} /opt/taudem/gagewatershed
+
+before_deploy:
+  - docker login -e . -p "${QUAY_PASSWORD}" -u "${QUAY_USER}" quay.io
+
+deploy:
+  - provider: script
+    script: ".travis/deploy.sh"
+    on:
+      repo: WikiWatershed/docker-rwd
+      branch: develop
+  - provider: script
+    script: ".travis/deploy.sh"
+    on:
+      repo: WikiWatershed/docker-rwd
+      tags: true

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -z "${TRAVIS_TAG}" ]; then
+  QUAY_TAG="${TRAVIS_COMMIT:0:7}"
+else
+  QUAY_TAG="${TRAVIS_TAG}"
+
+  docker tag -f "quay.io/wikiwatershed/rwd:${TRAVIS_COMMIT:0:7}" "quay.io/wikiwatershed/rwd:${QUAY_TAG}"
+fi
+
+docker push "quay.io/wikiwatershed/rwd:${QUAY_TAG}"
+docker tag -f "quay.io/wikiwatershed/rwd:${QUAY_TAG}" "quay.io/wikiwatershed/rwd:latest"
+docker push "quay.io/wikiwatershed/rwd:latest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0
+
+- Initial release
+
 ## 0.0.1
 
 - Initial provisioning

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # docker-rwd
 
+[![Travis CI](https://api.travis-ci.org/WikiWatershed/docker-rwd.svg "Build Status on Travis CI")](https://travis-ci.org/WikiWatershed/docker-rwd/)
+[![Docker Repository on Quay.io](https://quay.io/repository/wikiwatershed/rwd/status "Docker Repository on Quay.io")](https://quay.io/repository/wikiwatershed/rwd)
+[![Apache V2 License](http://img.shields.io/badge/license-Apache%20V2-blue.svg)](https://github.com/wikiwatershed/docker-rwd/blob/develop/LICENSE)
+
 A Docker image for [Rapid Watershed Delineation](https://github.com/WikiWatershed/rapid-watershed-delineation).


### PR DESCRIPTION
- Build on Travis and deploy images to Quay on success. Based off
  of other Azavea Docker repos like https://github.com/azavea/docker-django/
- Add service badges.

Refs WikiWatershed/model-my-watershed#1066
