### PR TITLE
Add flask configuration to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,3 +67,9 @@ RUN mkdir /opt/rwd/ && \
     | tar -xzC /opt/rwd --strip-components=1 && \
     cd /opt/rwd && \
     pip install --no-cache-dir -r requirements.txt
+
+RUN pip install -r /opt/rwd/src/api/requirements.txt
+# This line is needed for main.py to be able to find module rwd when
+# the rwd repo on the host is mounted to /opt/rwd for ease of development.
+ENV PYTHONPATH /opt/rwd/:$PYTHONPATH
+CMD ["python", "/opt/rwd/src/api/main.py"]


### PR DESCRIPTION
This modifies the Dockerfile to get a flask service running. See the associated PR  https://github.com/WikiWatershed/rapid-watershed-delineation/pull/7.

Connects https://github.com/WikiWatershed/model-my-watershed/issues/1067
##### Testing
- Check out the branch from the associated PR https://github.com/WikiWatershed/rapid-watershed-delineation/pull/7.
- Build the container image `docker build -t docker-rwd .` This should only take a few seconds thanks to caching.
- Run the container using

```
docker run \
-v <host_data_path>:/opt/rwd-data \
-v <host_rwd_repo_path>:/opt/rwd \
-p 5000:5000 \
docker-rwd
```
- On Linux, go to `localhost:5000/rwd/-75.276639/39.892986`. On OS X, find the ip of the default VM using `docker-machine ip default` and go to `<default_vm_ip>:5000/rwd/-75.276639/39.892986`
- After a few seconds, it should return GeoJSON.
##### Known issues (will do before merging)
- The endpoint function needs be more robust to failures.
- We need a way to automatically restart the flask service if it crashes for some reason. 
