### PR TITLE
Upgrade RWD to version 1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Azavea <systems@azavea.com>
 ENV GDAL_VERSION 1.11.0
 ENV OPEN_MPI_SHORT_VERSION 1.8
 ENV OPEN_MPI_VERSION 1.8.1
-ENV TAUDEM_VERSION Develop
+ENV TAUDEM_VERSION 5.3.2
 ENV RWD_VERSION 0.3.0
 
 RUN apt-get update && apt-get install -y \
@@ -39,10 +39,11 @@ RUN wget -qO- https://www.open-mpi.org/software/ompi/v${OPEN_MPI_SHORT_VERSION}/
     && ldconfig
 
 # Download and build taudem
-# Remove the TestSuite directory because it contains large files
-# that we don't need.
-RUN wget -qO- https://github.com/dtarb/TauDEM/archive/${TAUDEM_VERSION}.tar.gz \
+# The release tags start with "v" but the folder inside the archive doesn't.
+RUN wget -qO- https://github.com/dtarb/TauDEM/archive/v${TAUDEM_VERSION}.tar.gz \
     | tar -xzC /usr/src \
+    # Remove the TestSuite directory because it contains large files
+    # that we don't need.
     && rm -rf /usr/src/TauDEM-${TAUDEM_VERSION}/TestSuite \
     && cd /usr/src/TauDEM-${TAUDEM_VERSION}/src \
     && make

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV GDAL_VERSION 1.11.0
 ENV OPEN_MPI_SHORT_VERSION 1.8
 ENV OPEN_MPI_VERSION 1.8.1
 ENV TAUDEM_VERSION 5.3.2
-ENV RWD_VERSION 0.3.0
+ENV RWD_VERSION 1.0.0
 
 RUN apt-get update && apt-get install -y \
     build-essential \

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN wget -qO- https://github.com/dtarb/TauDEM/archive/v${TAUDEM_VERSION}.tar.gz 
     && rm -rf /usr/src/TauDEM-${TAUDEM_VERSION}/TestSuite \
     && cd /usr/src/TauDEM-${TAUDEM_VERSION}/src \
     && make
+RUN ln -s /usr/src/TauDEM-${TAUDEM_VERSION} /opt/taudem
 ENV PATH /opt/taudem:$PATH
 
 RUN pip install --upgrade pip

--- a/scripts/run-bash.sh
+++ b/scripts/run-bash.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+ARGS=$*
+
+echo "Run the RWD Docker container."
+
+if [ -z "$RWD_REPO" ]; then
+    echo "Environment variable RWD_REPO not defined."
+    exit 1
+fi
+
+if [ -z "$RWD_DATA" ]; then
+    echo "Environment variable RWD_DATA not defined."
+    exit 1
+fi
+
+set -x
+
+docker run \
+-v $RWD_DATA:/opt/rwd-data \
+-v $RWD_REPO:/opt/rwd \
+-p 5000:5000 \
+--rm \
+-ti --entrypoint=/bin/bash \
+$ARGS


### PR DESCRIPTION
Updates RWD version to the latest release (1.0.0) and fixes one minor runtime error.

Test by running the image and executing the following command on host:

> curl http://localhost:5000/rwd/39.814556386946684/-75.6863272190094

The result should be a valid GeoJSON file.

**Note:** You don't want to mount `RWD_REPO` inside the container so `./scripts/run.sh` may need to be modified to test this.
